### PR TITLE
HABI-31 Adding Goal Creation Support In Server + DAO

### DIFF
--- a/src/main/java/com/habicus/core/configuration/ServiceConfiguration/ServiceConfig.java
+++ b/src/main/java/com/habicus/core/configuration/ServiceConfiguration/ServiceConfig.java
@@ -23,6 +23,7 @@
 package com.habicus.core.configuration.ServiceConfiguration;
 
 import com.habicus.core.service.Goal.GoalService;
+import com.habicus.core.service.User.UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,5 +33,10 @@ public class ServiceConfig {
   @Bean
   public GoalService goalService() {
     return new GoalService();
+  }
+
+  @Bean
+  public UserService userService() {
+    return new UserService();
   }
 }

--- a/src/main/java/com/habicus/core/controller/v1/goal/GoalController.java
+++ b/src/main/java/com/habicus/core/controller/v1/goal/GoalController.java
@@ -23,12 +23,17 @@
 package com.habicus.core.controller.v1.goal;
 
 import com.habicus.core.model.Goal;
+import com.habicus.core.model.User;
 import com.habicus.core.service.Goal.GoalService;
+import com.habicus.core.service.User.UserService;
 import java.util.List;
 import java.util.logging.Logger;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,9 +46,16 @@ public class GoalController {
 
   private GoalService goalService;
 
+  private UserService userService;
+
   @Autowired
   public void setGoalService(GoalService goalService) {
     this.goalService = goalService;
+  }
+
+  @Autowired
+  public void setUserService(UserService userService) {
+    this.userService = userService;
   }
 
   /**
@@ -61,5 +73,26 @@ public class GoalController {
   public List<Goal> retrieveUserGoals(@PathVariable(value = "id") Long id) {
     LOGGER.info(String.format("Retrieving goals associated with user {}", id));
     return goalService.retrieveGoalsByUserId(id);
+  }
+
+  /**
+   * This enables the ability for a particular user to create a {@link Goal} object from the client
+   *
+   * @return
+   */
+  @RequestMapping(
+    value = "/{userId}",
+    method = RequestMethod.POST,
+    consumes = {MediaType.APPLICATION_JSON},
+    produces = MediaType.APPLICATION_JSON
+  )
+  public Response addGoal(@PathVariable String userId, @RequestBody Goal inputGoal) {
+    User user = userService.validateUserById(userId);
+    if (user != null) {
+      inputGoal.setUser(user);
+      goalService.saveUserGoal(inputGoal);
+      return Response.status(Status.OK).entity(inputGoal).build();
+    }
+    return Response.status(500, "User Not Found").build();
   }
 }

--- a/src/main/java/com/habicus/core/service/Goal/GoalService.java
+++ b/src/main/java/com/habicus/core/service/Goal/GoalService.java
@@ -25,6 +25,7 @@ package com.habicus.core.service.Goal;
 import com.habicus.core.dao.repository.GoalRepository;
 import com.habicus.core.model.Goal;
 import java.util.List;
+import javax.ws.rs.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -36,5 +37,16 @@ public class GoalService {
   public List<Goal> retrieveGoalsByUserId(Long id) {
     List<Goal> goals = goalRepository.findGoalsByUserId(id);
     return goals;
+  }
+
+  /**
+   * Allows a {@link com.habicus.core.model.User} to persist a {@link Goal} object into the DB
+   *
+   * @param goal
+   * @return
+   */
+  public Goal saveUserGoal(Goal goal) {
+    if (goal != null) return goalRepository.save(goal);
+    else throw new NotFoundException("Unable to save an empty goal");
   }
 }

--- a/src/main/java/com/habicus/core/service/User/UserService.java
+++ b/src/main/java/com/habicus/core/service/User/UserService.java
@@ -22,4 +22,37 @@
  */
 package com.habicus.core.service.User;
 
-public class UserService {}
+import com.habicus.core.dao.repository.UserRepository;
+import com.habicus.core.model.User;
+import java.util.logging.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Service
+public class UserService {
+
+  private static final Logger LOGGER = Logger.getLogger(UserService.class.getName());
+
+  @Autowired private UserRepository userRepo;
+  /**
+   * Allows the input requesting user id to be validated
+   *
+   * @param userId
+   * @return
+   */
+  public User validateUserById(String userId) {
+    return this.userRepo
+        .findById(Long.parseLong(userId))
+        .orElseThrow(() -> new UserNotFoundException(userId));
+  }
+
+  /** Used to validate existence of a particular {@link User} by it's associated {@link Long id} */
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  private class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String userId) {
+      super(String.format("Unable to find the user by the id: {}", userId));
+    }
+  }
+}


### PR DESCRIPTION
![](https://camo.githubusercontent.com/cf373500dfe17773807191f7fb730ea7ea4b959d/68747470733a2f2f692e696d6775722e636f6d2f5878585a6b6d4f2e706e67)

## Ticket Reference ([View Current Issues Here](https://github.com/Habicus/Habicus-Core/issues))
My Issue Number Is: Connects #31 


##### Core Reviewers:
@Habicus/core-team

##### Merge Owner:
@mweser
@Habicus/core-team
@austinsorrells
@schachte

## Status
**Ready + Needs Hero**

## Description
Adds ability to persist new goals by user ID in controller + service layer. 

## Completed The Following (If Relevant)
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Documentation

## Steps to Test or Reproduce
1. Load up dev server
2. Hit new endpoint on `http://localhost:7777/api/v1/goal/1` where the integer at the end represents the user ID
3. Make a POST req with JSON data that adheres to the Goal Model
