### PR TITLE
Updating PR template for Waffle

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ![](https://camo.githubusercontent.com/cf373500dfe17773807191f7fb730ea7ea4b959d/68747470733a2f2f692e696d6775722e636f6d2f5878585a6b6d4f2e706e67)
 
 ## Ticket Reference ([View Current Issues Here](https://github.com/Habicus/Habicus-Core/issues))
-My Issue Number Is: #
+My Issue Number connects #
 
 
 ##### Core Reviewers:


### PR DESCRIPTION
![](https://camo.githubusercontent.com/cf373500dfe17773807191f7fb730ea7ea4b959d/68747470733a2f2f692e696d6775722e636f6d2f5878585a6b6d4f2e706e67)

## Ticket Reference ([View Current Issues Here](https://github.com/Habicus/Habicus-Core/issues))
My Issue Number Connects #40 


##### Core Reviewers:
@Habicus/core-team

##### Merge Owner:
@mweser
@Habicus/core-team
@austinsorrells
@schachte

## Status
**Ready**

## Description
Waffle uses different reserved keywords for auto-linking issues. This simple change will link pull requests to issues in an automated fashion. 
