### PR TITLE
HABI-46 Deprecating XML Seeder

### DIFF
--- a/src/main/java/com/habicus/seeder/xmlloader/data/DataContainers/Container.java
+++ b/src/main/java/com/habicus/seeder/xmlloader/data/DataContainers/Container.java
@@ -20,35 +20,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.test.data.DataContainers;
+package com.habicus.seeder.xmlloader.data.DataContainers;
 
-import com.habicus.core.model.Goal;
+import com.habicus.seeder.xmlloader.data.Loader;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 
-/** Allows a container to hold a list of user and map to standard POJO */
-@XmlRootElement(name = "GoalContainer")
-@XmlAccessorType(XmlAccessType.FIELD)
-public class GoalContainer implements Container {
-
-  public GoalContainer() {}
-
-  @XmlElement(name = "goal")
-  private List<Goal> goals;
-
-  public List<Goal> getGoals() {
-    return goals;
-  }
-
-  public void setGoals(List<Goal> goals) {
-    this.goals = goals;
-  }
-
-  @Override
-  public List<Goal> getAll() {
-    return goals;
-  }
+/**
+ * Every test dao table will inherit Container in an effort to genericize the calls to grab all dao
+ * in the {@link Loader}. This greatly increases the amount of code reuse we can enable when
+ * iterating through and loading all the test dao into the database.
+ *
+ * @param <T>
+ */
+@Deprecated
+public interface Container<T> {
+  public List<T> getAll();
 }

--- a/src/main/java/com/habicus/seeder/xmlloader/data/DataContainers/GoalContainer.java
+++ b/src/main/java/com/habicus/seeder/xmlloader/data/DataContainers/GoalContainer.java
@@ -20,9 +20,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.test.data.DataContainers;
+package com.habicus.seeder.xmlloader.data.DataContainers;
 
-import com.habicus.core.model.User;
+import com.habicus.core.model.Goal;
 import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -30,25 +30,26 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /** Allows a container to hold a list of user and map to standard POJO */
-@XmlRootElement(name = "UserContainer")
+@XmlRootElement(name = "GoalContainer")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class UserContainer implements Container {
+@Deprecated
+public class GoalContainer implements Container {
 
-  public UserContainer() {}
+  public GoalContainer() {}
 
-  @XmlElement(name = "user")
-  private List<User> users;
+  @XmlElement(name = "goal")
+  private List<Goal> goals;
 
-  public List<User> getUsers() {
-    return users;
+  public List<Goal> getGoals() {
+    return goals;
   }
 
-  public void setUsers(List<User> users) {
-    this.users = users;
+  public void setGoals(List<Goal> goals) {
+    this.goals = goals;
   }
 
   @Override
-  public List<User> getAll() {
-    return users;
+  public List<Goal> getAll() {
+    return goals;
   }
 }

--- a/src/main/java/com/habicus/seeder/xmlloader/data/DataContainers/UserContainer.java
+++ b/src/main/java/com/habicus/seeder/xmlloader/data/DataContainers/UserContainer.java
@@ -20,18 +20,36 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.test.data.DataContainers;
+package com.habicus.seeder.xmlloader.data.DataContainers;
 
-import com.habicus.test.data.Loader;
+import com.habicus.core.model.User;
 import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 
-/**
- * Every test dao table will inherit Container in an effort to genericize the calls to grab all dao
- * in the {@link Loader}. This greatly increases the amount of code reuse we can enable when
- * iterating through and loading all the test dao into the database.
- *
- * @param <T>
- */
-public interface Container<T> {
-  public List<T> getAll();
+/** Allows a container to hold a list of user and map to standard POJO */
+@XmlRootElement(name = "UserContainer")
+@XmlAccessorType(XmlAccessType.FIELD)
+@Deprecated
+public class UserContainer implements Container {
+
+  public UserContainer() {}
+
+  @XmlElement(name = "user")
+  private List<User> users;
+
+  public List<User> getUsers() {
+    return users;
+  }
+
+  public void setUsers(List<User> users) {
+    this.users = users;
+  }
+
+  @Override
+  public List<User> getAll() {
+    return users;
+  }
 }

--- a/src/main/java/com/habicus/seeder/xmlloader/data/DataLoaderRegistrar.java
+++ b/src/main/java/com/habicus/seeder/xmlloader/data/DataLoaderRegistrar.java
@@ -20,13 +20,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.test.data;
+package com.habicus.seeder.xmlloader.data;
 
 import com.habicus.core.dao.repository.GoalRepository;
 import com.habicus.core.dao.repository.UserRepository;
 import com.habicus.core.model.Goal;
 import com.habicus.core.model.User;
-import com.habicus.test.data.DataContainers.Container;
+import com.habicus.seeder.xmlloader.data.DataContainers.Container;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -49,6 +49,7 @@ import org.springframework.stereotype.Component;
  *       com.habicus.test.data.DataContainers}
  * </ol>
  */
+@Deprecated
 @Component
 public class DataLoaderRegistrar {
 

--- a/src/main/java/com/habicus/seeder/xmlloader/data/Loader.java
+++ b/src/main/java/com/habicus/seeder/xmlloader/data/Loader.java
@@ -20,12 +20,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.test.data;
+package com.habicus.seeder.xmlloader.data;
 
 import static java.lang.Class.*;
 
 import com.habicus.core.configuration.CoreConstants;
-import com.habicus.test.data.DataContainers.Container;
+import com.habicus.seeder.xmlloader.data.DataContainers.Container;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.logging.Level;
@@ -35,17 +35,15 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.ApplicationListener;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.*;
-import org.springframework.stereotype.Component;
 
 /**
  * Launches at application boot-time to inject any user-defined test dao and stores into test
  * database automatically.
  */
-@Component
-public class Loader implements ApplicationListener<ApplicationReadyEvent> {
+@Deprecated
+public class Loader {
 
   private static final Logger LOGGER = Logger.getLogger(Loader.class.getName());
 
@@ -110,16 +108,15 @@ public class Loader implements ApplicationListener<ApplicationReadyEvent> {
     }
   }
 
-  @Override
+  /**
+   * Initial method of preloading XML -> SQL dynamically with JaxB @Deprecated to move into
+   * schema-based loading
+   *
+   * @param event
+   */
+  @Deprecated
   public void onApplicationEvent(ApplicationReadyEvent event) {
-    LOGGER.log(Level.INFO, "Preparing to load dao into database");
-
-    try {
-      loadTestContainers();
-    } catch (IOException e) {
-      LOGGER.log(Level.INFO, "Unable to store user dao");
-      e.printStackTrace();
-    }
+    LOGGER.log(Level.INFO, "Loader Disabled");
   }
 
   /**


### PR DESCRIPTION
![](https://camo.githubusercontent.com/cf373500dfe17773807191f7fb730ea7ea4b959d/68747470733a2f2f692e696d6775722e636f6d2f5878585a6b6d4f2e706e67)


#### Ticket Reference ([View Current Issues Here](https://github.com/Habicus/Habicus-Core/issues))
My Issue Number Connects #46 

##### Backlog & Current Sprint ([View Backlog Here](https://waffle.io/Habicus/Habicus-Core-Web))


##### Core Reviewers:
@Habicus/core-team

##### Merge Owner:
@Habicus/core-team
@austinsorrells
@schachte

## Status
**Ready**

## Description
Deprecates initial data loader API for XML -> SQL in favor of SQL Schemas in Spring
