### PR TITLE
HABI-31 - Adding initial goal controller using new persistence layer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile("com.h2database:h2")
     compile('org.springframework.boot:spring-boot-starter-data-jpa')
     compile('mysql:mysql-connector-java:5.1.6')
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.3.0-rc1'
 
     testCompile 'junit:junit:4.12'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.0.1.RELEASE'

--- a/src/main/java/com/habicus/core/controller/v1/goal/GoalController.java
+++ b/src/main/java/com/habicus/core/controller/v1/goal/GoalController.java
@@ -22,16 +22,28 @@
  */
 package com.habicus.core.controller.v1.goal;
 
+import com.habicus.core.exception.API.InvalidRequestException;
+import com.habicus.core.exception.NoGoalsFoundException;
+import com.habicus.core.model.Goals;
 import com.habicus.core.model.User;
 import com.habicus.core.service.Goal.GoalService;
+import java.util.List;
+import java.util.Optional;
 import com.habicus.core.service.User.UserService;
 import java.util.logging.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/goal")
+@ControllerAdvice
+@RequestMapping("/api/v1")
 public class GoalController {
 
   private static final Logger LOGGER = Logger.getLogger(GoalController.class.getName());
@@ -42,6 +54,26 @@ public class GoalController {
   @Autowired
   public void setGoalService(GoalService goalService) {
     this.goalService = goalService;
+  }
+
+  /**
+   * Allows retrieval by a single userId for getting goals
+   *
+   * @param userId
+   * @return
+   * @throws NoGoalsFoundException
+   */
+  @ExceptionHandler(NoGoalsFoundException.class)
+  @GetMapping("/goal/{userId}")
+  public ResponseEntity<List<Goals>> getGoalsByUserId(@PathVariable("userId") int userId)
+      throws NoGoalsFoundException {
+
+    Optional<List<Goals>> goalList = goalService.retrieveGoalsByUserId(userId);
+    if (!goalList.isPresent()) {
+      throw new InvalidRequestException(
+          String.format("No goals found for requesting user: " + userId), HttpStatus.NOT_FOUND);
+    }
+    return new ResponseEntity<>(goalList.get(), HttpStatus.OK);
   }
 
   @Autowired

--- a/src/main/java/com/habicus/core/controller/v1/goal/GoalController.java
+++ b/src/main/java/com/habicus/core/controller/v1/goal/GoalController.java
@@ -24,12 +24,11 @@ package com.habicus.core.controller.v1.goal;
 
 import com.habicus.core.exception.API.InvalidRequestException;
 import com.habicus.core.exception.NoGoalsFoundException;
-import com.habicus.core.model.Goals;
-import com.habicus.core.model.User;
+import com.habicus.core.model.Goal;
 import com.habicus.core.service.Goal.GoalService;
+import com.habicus.core.service.User.UserService;
 import java.util.List;
 import java.util.Optional;
-import com.habicus.core.service.User.UserService;
 import java.util.logging.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -65,10 +64,10 @@ public class GoalController {
    */
   @ExceptionHandler(NoGoalsFoundException.class)
   @GetMapping("/goal/{userId}")
-  public ResponseEntity<List<Goals>> getGoalsByUserId(@PathVariable("userId") int userId)
+  public ResponseEntity<List<Goal>> getGoalsByUserId(@PathVariable("userId") int userId)
       throws NoGoalsFoundException {
 
-    Optional<List<Goals>> goalList = goalService.retrieveGoalsByUserId(userId);
+    Optional<List<Goal>> goalList = goalService.retrieveGoalsByUserId(userId);
     if (!goalList.isPresent()) {
       throw new InvalidRequestException(
           String.format("No goals found for requesting user: " + userId), HttpStatus.NOT_FOUND);

--- a/src/main/java/com/habicus/core/dao/repository/GoalRepository.java
+++ b/src/main/java/com/habicus/core/dao/repository/GoalRepository.java
@@ -22,29 +22,29 @@
  */
 package com.habicus.core.dao.repository;
 
-import com.habicus.core.model.Goals;
+import com.habicus.core.model.Goal;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GoalRepository extends JpaRepository<Goals, Long> {
+public interface GoalRepository extends JpaRepository<Goal, Long> {
 
   /**
-   * Allows retrieval of all {@link Goals} that are associated with a particular {@link
-   * com.habicus.core.model.Users}
+   * Allows retrieval of all {@link Goal} that are associated with a particular {@link
+   * com.habicus.core.model.User}
    *
    * @param userId
    * @return
    */
-  Optional<List<Goals>> getGoalsByUsersUserId(int userId);
+  Optional<List<Goal>> getGoalsByUsersUserId(int userId);
 
   /**
-   * Get a singular {@link Goals} that is associated with a goal id that is stored as metadata
+   * Get a singular {@link Goal} that is associated with a goal id that is stored as metadata
    *
    * @param goalId
    * @return
    */
-  Optional<Goals> getGoalsByGoalId(int goalId);
+  Optional<Goal> getGoalsByGoalId(int goalId);
 }

--- a/src/main/java/com/habicus/core/exception/API/APIExceptionHandler.java
+++ b/src/main/java/com/habicus/core/exception/API/APIExceptionHandler.java
@@ -1,0 +1,49 @@
+/*
+ _   _       _     _
+| | | | __ _| |__ (_) ___ _   _ ___
+| |_| |/ _` | '_ \| |/ __| | | / __|
+|  _  | (_| | |_) | | (__| |_| \__ \
+|_| |_|\__,_|_.__/|_|\___|\__,_|___/
+
+ * This file is part of the Habicus Core Platform (https://github.com/Habicus/Habicus-Core).
+ * Copyright (c) 2018 Habicus Core
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.habicus.core.exception.API;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class APIExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler({InvalidRequestException.class})
+  protected ResponseEntity<Object> handleInvalidRequest(RuntimeException e, WebRequest request) {
+    InvalidRequestException ire = (InvalidRequestException) e;
+
+    ErrorResource error = new ErrorResource("Invalid Request", ire.getMessage());
+    error.setCode(ire.getStatusCodeError().toString());
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    return handleExceptionInternal(e, error, headers, HttpStatus.UNPROCESSABLE_ENTITY, request);
+  }
+}

--- a/src/main/java/com/habicus/core/exception/API/ErrorResource.java
+++ b/src/main/java/com/habicus/core/exception/API/ErrorResource.java
@@ -20,31 +20,45 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.core.dao.repository;
+package com.habicus.core.exception.API;
 
-import com.habicus.core.model.Goals;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface GoalRepository extends JpaRepository<Goals, Long> {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ErrorResource {
+  private String code;
+  private String message;
+  private List<FieldErrorResource> fieldErrors;
 
-  /**
-   * Allows retrieval of all {@link Goals} that are associated with a particular {@link
-   * com.habicus.core.model.Users}
-   *
-   * @param userId
-   * @return
-   */
-  Optional<List<Goals>> getGoalsByUsersUserId(int userId);
+  public ErrorResource() {}
 
-  /**
-   * Get a singular {@link Goals} that is associated with a goal id that is stored as metadata
-   *
-   * @param goalId
-   * @return
-   */
-  Optional<Goals> getGoalsByGoalId(int goalId);
+  public ErrorResource(String code, String message) {
+    this.code = code;
+    this.message = message;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public List<FieldErrorResource> getFieldErrors() {
+    return fieldErrors;
+  }
+
+  public void setFieldErrors(List<FieldErrorResource> fieldErrors) {
+    this.fieldErrors = fieldErrors;
+  }
 }

--- a/src/main/java/com/habicus/core/exception/API/FieldErrorResource.java
+++ b/src/main/java/com/habicus/core/exception/API/FieldErrorResource.java
@@ -20,31 +20,46 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.core.dao.repository;
+package com.habicus.core.exception.API;
 
-import com.habicus.core.model.Goals;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@Repository
-public interface GoalRepository extends JpaRepository<Goals, Long> {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FieldErrorResource {
+  private String resource;
+  private String field;
+  private String code;
+  private String message;
 
-  /**
-   * Allows retrieval of all {@link Goals} that are associated with a particular {@link
-   * com.habicus.core.model.Users}
-   *
-   * @param userId
-   * @return
-   */
-  Optional<List<Goals>> getGoalsByUsersUserId(int userId);
+  public String getResource() {
+    return resource;
+  }
 
-  /**
-   * Get a singular {@link Goals} that is associated with a goal id that is stored as metadata
-   *
-   * @param goalId
-   * @return
-   */
-  Optional<Goals> getGoalsByGoalId(int goalId);
+  public void setResource(String resource) {
+    this.resource = resource;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  public void setField(String field) {
+    this.field = field;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
 }

--- a/src/main/java/com/habicus/core/exception/API/InvalidRequestException.java
+++ b/src/main/java/com/habicus/core/exception/API/InvalidRequestException.java
@@ -20,31 +20,21 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.core.dao.repository;
+package com.habicus.core.exception.API;
 
-import com.habicus.core.model.Goals;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.http.HttpStatus;
 
-@Repository
-public interface GoalRepository extends JpaRepository<Goals, Long> {
+@SuppressWarnings("serial")
+public class InvalidRequestException extends RuntimeException {
 
-  /**
-   * Allows retrieval of all {@link Goals} that are associated with a particular {@link
-   * com.habicus.core.model.Users}
-   *
-   * @param userId
-   * @return
-   */
-  Optional<List<Goals>> getGoalsByUsersUserId(int userId);
+  HttpStatus statusCode;
 
-  /**
-   * Get a singular {@link Goals} that is associated with a goal id that is stored as metadata
-   *
-   * @param goalId
-   * @return
-   */
-  Optional<Goals> getGoalsByGoalId(int goalId);
+  public InvalidRequestException(String message, HttpStatus statusCode) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+
+  public HttpStatus getStatusCodeError() {
+    return this.statusCode;
+  }
 }

--- a/src/main/java/com/habicus/core/exception/NoGoalsFoundException.java
+++ b/src/main/java/com/habicus/core/exception/NoGoalsFoundException.java
@@ -20,31 +20,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.core.dao.repository;
+package com.habicus.core.exception;
 
-import com.habicus.core.model.Goals;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-@Repository
-public interface GoalRepository extends JpaRepository<Goals, Long> {
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NoGoalsFoundException extends RuntimeException {
 
-  /**
-   * Allows retrieval of all {@link Goals} that are associated with a particular {@link
-   * com.habicus.core.model.Users}
-   *
-   * @param userId
-   * @return
-   */
-  Optional<List<Goals>> getGoalsByUsersUserId(int userId);
+  public NoGoalsFoundException() {
+    super();
+  }
 
-  /**
-   * Get a singular {@link Goals} that is associated with a goal id that is stored as metadata
-   *
-   * @param goalId
-   * @return
-   */
-  Optional<Goals> getGoalsByGoalId(int goalId);
+  public NoGoalsFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/habicus/core/exception/StandardGoalException.java
+++ b/src/main/java/com/habicus/core/exception/StandardGoalException.java
@@ -20,31 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.core.dao.repository;
+package com.habicus.core.exception;
 
-import com.habicus.core.model.Goals;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface GoalRepository extends JpaRepository<Goals, Long> {
-
-  /**
-   * Allows retrieval of all {@link Goals} that are associated with a particular {@link
-   * com.habicus.core.model.Users}
-   *
-   * @param userId
-   * @return
-   */
-  Optional<List<Goals>> getGoalsByUsersUserId(int userId);
-
-  /**
-   * Get a singular {@link Goals} that is associated with a goal id that is stored as metadata
-   *
-   * @param goalId
-   * @return
-   */
-  Optional<Goals> getGoalsByGoalId(int goalId);
-}
+public class StandardGoalException {}

--- a/src/main/java/com/habicus/core/exception/StandardUserException.java
+++ b/src/main/java/com/habicus/core/exception/StandardUserException.java
@@ -20,31 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.habicus.core.dao.repository;
+package com.habicus.core.exception;
 
-import com.habicus.core.model.Goals;
-import java.util.List;
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface GoalRepository extends JpaRepository<Goals, Long> {
-
-  /**
-   * Allows retrieval of all {@link Goals} that are associated with a particular {@link
-   * com.habicus.core.model.Users}
-   *
-   * @param userId
-   * @return
-   */
-  Optional<List<Goals>> getGoalsByUsersUserId(int userId);
-
-  /**
-   * Get a singular {@link Goals} that is associated with a goal id that is stored as metadata
-   *
-   * @param goalId
-   * @return
-   */
-  Optional<Goals> getGoalsByGoalId(int goalId);
-}
+public class StandardUserException {}

--- a/src/main/java/com/habicus/core/service/Goal/GoalService.java
+++ b/src/main/java/com/habicus/core/service/Goal/GoalService.java
@@ -24,7 +24,11 @@ package com.habicus.core.service.Goal;
 
 import com.habicus.core.dao.repository.GoalRepository;
 import com.habicus.core.dao.repository.UserRepository;
+import com.habicus.core.exception.NoGoalsFoundException;
+import com.habicus.core.model.Goals;
 import com.habicus.core.service.User.UserService;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -37,4 +41,16 @@ public class GoalService {
 
   // Service definitions
   @Autowired private UserService userService;
+
+  /**
+   * Allows retrieval of a list of goals that can be deserialized into JSON to the client
+   *
+   * @param userId
+   * @return Returns an array list of {@link Goals}
+   */
+  public Optional<List<Goals>> retrieveGoalsByUserId(int userId) throws NoGoalsFoundException {
+    // TODO: Need to actually do validation on this input userId with the req. token
+    Optional<List<Goals>> userGoals = goalRepository.getGoalsByUsersUserId(userId);
+    return userGoals;
+  }
 }

--- a/src/main/java/com/habicus/core/service/Goal/GoalService.java
+++ b/src/main/java/com/habicus/core/service/Goal/GoalService.java
@@ -25,7 +25,7 @@ package com.habicus.core.service.Goal;
 import com.habicus.core.dao.repository.GoalRepository;
 import com.habicus.core.dao.repository.UserRepository;
 import com.habicus.core.exception.NoGoalsFoundException;
-import com.habicus.core.model.Goals;
+import com.habicus.core.model.Goal;
 import com.habicus.core.service.User.UserService;
 import java.util.List;
 import java.util.Optional;
@@ -46,11 +46,11 @@ public class GoalService {
    * Allows retrieval of a list of goals that can be deserialized into JSON to the client
    *
    * @param userId
-   * @return Returns an array list of {@link Goals}
+   * @return Returns an array list of {@link Goal}
    */
-  public Optional<List<Goals>> retrieveGoalsByUserId(int userId) throws NoGoalsFoundException {
+  public Optional<List<Goal>> retrieveGoalsByUserId(int userId) throws NoGoalsFoundException {
     // TODO: Need to actually do validation on this input userId with the req. token
-    Optional<List<Goals>> userGoals = goalRepository.getGoalsByUsersUserId(userId);
+    Optional<List<Goal>> userGoals = goalRepository.getGoalsByUsersUserId(userId);
     return userGoals;
   }
 }

--- a/src/main/java/com/habicus/core/service/User/UserService.java
+++ b/src/main/java/com/habicus/core/service/User/UserService.java
@@ -39,8 +39,7 @@ public class UserService {
    * @return
    */
   public User retrieveUserByEmail(String email) {
-    return
-        Stream.of(userRepository.findByEmail(email))
+    return Stream.of(userRepository.findByEmail(email))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .findFirst()

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -10,4 +10,6 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL5Dialect
 spring.datasource.platform=mysql
 spring.jpa.hibernate.ddl-auto=none
 spring.datasource.initialization-mode=always
+
+## Keep disabled to view errors in DB initialization in the dev env
 #spring.datasource.continueOnError=true


### PR DESCRIPTION
![](https://camo.githubusercontent.com/cf373500dfe17773807191f7fb730ea7ea4b959d/68747470733a2f2f692e696d6775722e636f6d2f5878585a6b6d4f2e706e67)


#### Ticket Reference ([View Current Issues Here](https://github.com/Habicus/Habicus-Core/issues))

##### Backlog & Current Sprint ([View Backlog Here](https://waffle.io/Habicus/Habicus-Core-Web))

My Issue Number Connects #31 


##### Core Reviewers:
@Habicus/core-team

##### Merge Owner:
@austinsorrells
@schachte

## Status
**Work In Progress (Do Not Merge)**

## Description
Adds initial Goal controller with:
- custom exceptions
- new API layer

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
HABI-48 | [https://github.com/Habicus/Habicus-Core-Web/pull/49](HABI-48)


## Completed The Following (If Relevant)
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Documentation
